### PR TITLE
Update Exchange build numbers through August 2026

### DIFF
--- a/ExchangeBuildNumbers.csv
+++ b/ExchangeBuildNumbers.csv
@@ -234,6 +234,9 @@ Exchange 2016 CU23 Sep25HU,15.1.2507.59,9/8/2025,KB5066370,https://techcommunity
 Exchange 2016 CU23 Oct25SU,15.1.2507.61,10/14/2025,KB5066369,https://techcommunity.microsoft.com/blog/exchange/released-october-2025-exchange-server-security-updates/4461276
 Exchange 2016 CU23 Dec25SU,15.1.2507.63,12/9/2025,KB5071873,https://techcommunity.microsoft.com/blog/exchange/released-december-2025-exchange-server-security-updates/4474949
 Exchange 2016 CU23 Feb26SU,15.1.2507.66,2/10/2026,KB5074995,https://techcommunity.microsoft.com/blog/exchange/released-february-2026-exchange-server-security-updates/4494076
+Exchange 2016 CU23 Jun26SU,15.1.2507.69,6/9/2026,KB5094144,https://techcommunity.microsoft.com/blog/exchange/released-june-2026-exchange-server-security-updates/4524491
+Exchange 2016 CU23 Jul26SU,15.1.2507.71,7/14/2026,KB5103215,https://techcommunity.microsoft.com/blog/exchange/released-july-2026-exchange-server-security-updates/4534146
+Exchange 2016 CU23 Aug26SU,15.1.2507.72,8/11/2026,KB5121576,https://techcommunity.microsoft.com/blog/exchange/released-august-2026-exchange-server-security-updates/4543951
 Exchange 2019 Preview,15.2.196.0,7/24/2018,,
 Exchange 2019 RTM,15.2.221.12,10/22/2018,,https://techcommunity.microsoft.com/t5/exchange-team-blog/exchange-server-2019-now-available/ba-p/608610
 Exchange 2019 RTM Mar21SU,15.2.221.18,3/2/2021,KB5000871,https://techcommunity.microsoft.com/t5/exchange-team-blog/march-2021-exchange-server-security-updates-for-older-cumulative/ba-p/2192020
@@ -312,6 +315,9 @@ Exchange 2019 CU14 Sep25HU,15.2.1544.34,9/8/2025,KB5066371,https://techcommunity
 Exchange 2019 CU14 Oct25SU,15.2.1544.36,10/14/2025,KB5066368,https://techcommunity.microsoft.com/blog/exchange/released-october-2025-exchange-server-security-updates/4461276
 Exchange 2019 CU14 Dec25SU,15.2.1544.37,12/9/2025,KB5071874,https://techcommunity.microsoft.com/blog/exchange/released-december-2025-exchange-server-security-updates/4474949
 Exchange 2019 CU14 Feb26SU,15.2.1544.39,2/10/2026,KB5074994,https://techcommunity.microsoft.com/blog/exchange/released-february-2026-exchange-server-security-updates/4494076
+Exchange 2019 CU14 Jun26SU,15.2.1544.41,6/9/2026,KB5094142,https://techcommunity.microsoft.com/blog/exchange/released-june-2026-exchange-server-security-updates/4524491
+Exchange 2019 CU14 Jul26SU,15.2.1544.43,7/14/2026,KB5103214,https://techcommunity.microsoft.com/blog/exchange/released-july-2026-exchange-server-security-updates/4534146
+Exchange 2019 CU14 Aug26SU,15.2.1544.44,8/11/2026,KB5121575,https://techcommunity.microsoft.com/blog/exchange/released-august-2026-exchange-server-security-updates/4543951
 Exchange 2019 CU15,15.2.1748.10,2/10/2025,KB5042461,https://techcommunity.microsoft.com/blog/exchange/released-2025-h1-cumulative-update-for-exchange-server/4362055
 Exchange 2019 CU15 Apr25HU,15.2.1748.24,4/18/2025,KB5050674,https://techcommunity.microsoft.com/blog/exchange/released-april-2025-exchange-server-hotfix-updates/4402471
 Exchange 2019 CU15 May25HU,15.2.1748.26,5/29/2025,KB5057653,https://techcommunity.microsoft.com/blog/exchange/released-may-2025-exchange-server-hotfix-updates/4418786
@@ -320,6 +326,9 @@ Exchange 2019 CU15 Sep25HU,15.2.1748.37,9/8/2025,KB5066372,https://techcommunity
 Exchange 2019 CU15 Oct25SU,15.2.1748.39,10/14/2025,KB5066367,https://techcommunity.microsoft.com/blog/exchange/released-october-2025-exchange-server-security-updates/4461276
 Exchange 2019 CU15 Dec25SU,15.2.1748.42,12/9/2025,KB5071875,https://techcommunity.microsoft.com/blog/exchange/released-december-2025-exchange-server-security-updates/4474949
 Exchange 2019 CU15 Feb26SU,15.2.1748.43,2/10/2026,KB5074993,https://techcommunity.microsoft.com/blog/exchange/released-february-2026-exchange-server-security-updates/4494076
+Exchange 2019 CU15 Jun26SU,15.2.1748.46,6/9/2026,KB5094140,https://techcommunity.microsoft.com/blog/exchange/released-june-2026-exchange-server-security-updates/4524491
+Exchange 2019 CU15 Jul26SU,15.2.1748.48,7/14/2026,KB5103213,https://techcommunity.microsoft.com/blog/exchange/released-july-2026-exchange-server-security-updates/4534146
+Exchange 2019 CU15 Aug26SU,15.2.1748.49,8/11/2026,KB5121574,https://techcommunity.microsoft.com/blog/exchange/released-august-2026-exchange-server-security-updates/4543951
 Exchange SE RTM,15.2.2562.17,7/1/2025,KB5047155,https://techcommunity.microsoft.com/blog/exchange/exchange-server-subscription-edition-se-is-now-available/4424924
 Exchange SE RTM Aug25SU,15.2.2562.20,8/12/2025,KB5063224,https://techcommunity.microsoft.com/blog/exchange/released-august-2025-exchange-server-security-updates/4441596
 Exchange SE RTM Sep25HU,15.2.2562.27,9/8/2025,KB5066373,https://techcommunity.microsoft.com/blog/exchange/released-september-2025-exchange-server-hotfix-updates/4448721
@@ -327,3 +336,6 @@ Exchange SE RTM Oct25SU,15.2.2562.29,10/14/2025,KB5066366,https://techcommunity.
 Exchange SE RTM Dec25SU,15.2.2562.35,12/9/2025,KB5071876,https://techcommunity.microsoft.com/blog/exchange/released-december-2025-exchange-server-security-updates/4474949
 Exchange SE RTM Feb26SU,15.2.2562.37,2/10/2026,KB5074992,https://techcommunity.microsoft.com/blog/exchange/released-february-2026-exchange-server-security-updates/4494076
 Exchange SE RTM May26HU,15.2.2562.41,5/7/2026,KB5081755,https://techcommunity.microsoft.com/blog/exchange/released-may-2026-exchange-server-hotfix-update/4517516
+Exchange SE RTM Jun26SU,15.2.2562.43,6/9/2026,KB5094139,https://techcommunity.microsoft.com/blog/exchange/released-june-2026-exchange-server-security-updates/4524491
+Exchange SE RTM Jul26SU,15.2.2562.45,7/14/2026,KB5103212,https://techcommunity.microsoft.com/blog/exchange/released-july-2026-exchange-server-security-updates/4534146
+Exchange SE RTM Aug26SU,15.2.2562.46,8/11/2026,KB5121573,https://techcommunity.microsoft.com/blog/exchange/released-august-2026-exchange-server-security-updates/4543951


### PR DESCRIPTION
## Why

Keep the Exchange build definition current with the Microsoft Learn build number table so users can identify the latest Exchange Server releases.

## What changed

- Added 12 missing June, July, and August 2026 entries for Exchange Server 2016, 2019, and Subscription Edition.
- Included the corresponding build numbers, release dates, KB articles, and official Exchange Team Blog URLs.
- Preserved the existing CSV ordering and naming conventions.

## Validation

- Confirmed all 12 expected product/build mappings are present.
- Confirmed there are no duplicate build numbers or invalid versions.
- Confirmed the complete CSV remains in build-number order.

Pre-existing KB number inconsistencies in some April and May 2025 HU entries were identified but intentionally left unchanged because this change is limited to adding missing releases.